### PR TITLE
[trigger] MAGETWO-95532: Unable to upload image from TinyMCE3

### DIFF
--- a/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminDisablePageBuilderCMSPageTests.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminDisablePageBuilderCMSPageTests.xml
@@ -15,14 +15,14 @@
             <actionGroup ref="enablePageBuilderSetting" stepKey="turnOnPageBuilder" before="amOnLogoutPage"/>
         </after>
     </test>
-    <test name="AdminAddImageToCMSPageTinyMCE3Test">
-        <before>
-            <magentoCLI command="config:set cms/pagebuilder/enabled 0" stepKey="turnOffPageBuilder" before="loginAsAdmin"/>
-        </before>
-        <after>
-            <magentoCLI command="config:set cms/pagebuilder/enabled 1" stepKey="turnOnPageBuilder" after="logout"/>
-        </after>
-    </test>
+     <test name="AdminAddImageToCMSPageTinyMCE3Test">
+         <before>
+            <magentoCLI command="config:set cms/pagebuilder/enabled 0" stepKey="disablePageBuilder" before="loginAsAdmin"/>
+         </before>
+         <after>
+            <magentoCLI command="config:set cms/pagebuilder/enabled 1" stepKey="enablePageBuilder" after="logout"/>
+         </after>
+     </test>
     <test name="AdminCreateDuplicatedCmsPageTest">
         <before>
             <actionGroup ref="disablePageBuilderSetting" stepKey="turnOffPageBuilder" after="loginGetFromGeneralFile"/>


### PR DESCRIPTION
## Scope
### Bug
* [MAGETWO-95532](https://jira.corp.magento.com/browse/MAGETWO-95532) Unable to upload image from TinyMCE3

### Related Pull Requests
<!--@relatedpullrequests-->
### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
