### PR TITLE
[Owls] Product description does not default to Page Builder on fresh install

### DIFF
--- a/app/code/Magento/PageBuilder/Setup/Patch/Data/UpdateProductAttribute.php
+++ b/app/code/Magento/PageBuilder/Setup/Patch/Data/UpdateProductAttribute.php
@@ -6,16 +6,15 @@
 
 declare(strict_types=1);
 
-namespace Magento\PageBuilderDataMigration\Setup\Patch\Data;
+namespace Magento\PageBuilder\Setup\Patch\Data;
 
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 
 /**
- * Patch is mechanism, that allows to do atomic upgrade data changes
+ * Update description product attribute to by default enable Page Builder
  */
-class UpdateProductAttribute implements
-    DataPatchInterface
+class UpdateProductAttribute implements DataPatchInterface
 {
     /**
      * @var ModuleDataSetupInterface $moduleDataSetup
@@ -40,7 +39,7 @@ class UpdateProductAttribute implements
     }
 
     /**
-     * Do Upgrade
+     * Modify EAV tables to update description attribute page builder enabled value
      *
      * @return void
      */
@@ -72,6 +71,6 @@ class UpdateProductAttribute implements
      */
     public static function getDependencies()
     {
-        return [MigrateToPageBuilder::class];
+        return [];
     }
 }


### PR DESCRIPTION
## Scope

### Bugs
* [MC-14947](https://jira.corp.magento.com/browse/MC-14947) Product description does not default to Page Builder on fresh install

### Jenkins Builds
https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/14168/ 

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red)
- [ ] Pull Request approved by architect (optional)
- [ ] Pull Request quality review performed by @anthoula
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] [Jenkins Extended FAT build is green]