### PR TITLE
MC-15336: Revert MC-11044 to restore builds

### DIFF
--- a/dev/tests/functional/tests/app/Magento/Bundle/Test/TestCase/PageBuilderCreateBundleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Bundle/Test/TestCase/PageBuilderCreateBundleProductEntityTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Bundle\Test\TestCase\CreateBundleProductEntityTest" summary="Create Bundle Product" ticketId="MAGETWO-24118">
+        <variation name="CreateBundleProductEntityTestVariation4" summary="Create bundle product with out of stock simple product" ticketId="MAGETWO-12801">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Category/PageBuilderCreateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Category/PageBuilderCreateCategoryEntityTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Catalog\Test\TestCase\Category\CreateCategoryEntityTest" summary="Create Category from Category Page" ticketId="MAGETWO-23411">
+        <variation name="CreateCategoryEntityTestVariation5_Anchor_MostOfFields">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Category/PageBuilderUpdateCategoryEntityFlatDataTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Category/PageBuilderUpdateCategoryEntityFlatDataTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Catalog\Test\TestCase\Category\UpdateCategoryEntityFlatDataTest" summary="Update Category if Use Category Flat (Cron is ON, 'Update on Save' Mode)" ticketId="MAGETWO-20169">
+        <variation name="UpdateCategoryEntityFlatDataTestVariation1" summary="Update Category with custom name and description">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Category/PageBuilderUpdateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Category/PageBuilderUpdateCategoryEntityTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Catalog\Test\TestCase\Category\UpdateCategoryEntityTest" summary="Update Category" ticketId="MAGETWO-23290">
+        <variation name="UpdateCategoryEntityTestVariation1_Name_Description_UrlKey_MetaTitle_ExcludeFromMenu">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/PageBuilderCreateSimpleProductEntityPartOneTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/PageBuilderCreateSimpleProductEntityPartOneTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Catalog\Test\TestCase\Product\CreateSimpleProductEntityPartOneTest" summary="Create Simple Product" ticketId="MAGETWO-23414">
+        <variation name="CreateSimpleProductEntityTestVariation13">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation14">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation15">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation16">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation17">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation18" summary="Create simple product with imported options" ticketId="MAGETWO-71386">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/PageBuilderCreateSimpleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/PageBuilderCreateSimpleProductEntityTest.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Catalog\Test\TestCase\Product\CreateSimpleProductEntityTest" summary="Create Simple Product" ticketId="MAGETWO-23414">
+        <variation name="CreateSimpleProductEntityTestVariation1">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation2">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation3" summary="Create product with special price and custom options(fixed price)">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation4">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation5">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation6">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation7">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation8">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateSimpleProductEntityTestVariation9">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/ProductAttribute/PageBuilderCreateProductAttributeEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/ProductAttribute/PageBuilderCreateProductAttributeEntityTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Catalog\Test\TestCase\ProductAttribute\CreateProductAttributeEntityTest" summary="Create Product Attribute" ticketId="MAGETWO-24767">
+        <variation name="CreateProductAttributeEntityTestVariation6" summary="Create custom dropdown attribute product field" ticketId="MAGETWO-17475, MAGETWO-14862">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Cms/Test/TestCase/PageBuilderCreateCmsPageEntityMultipleStoreViewsTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Cms/Test/TestCase/PageBuilderCreateCmsPageEntityMultipleStoreViewsTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Cms\Test\TestCase\CreateCmsPageEntityMultipleStoreViewsTest" summary="Page cache for different CMS pages on multiple store views" ticketId="MAGETWO-52467">
+        <variation name="CreateCmsPageEntityMultipleStoreViewsTestVariation1">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Cms/Test/TestCase/PageBuilderUpdateCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Cms/Test/TestCase/PageBuilderUpdateCmsPageEntityTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Cms\Test\TestCase\UpdateCmsPageEntityTest" summary="Update Cms Page" ticketId="MAGETWO-25186">
+        <variation name="UpdateCmsPageEntityTestVariation2">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/TestCase/PageBuilderCreateConfigurableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/TestCase/PageBuilderCreateConfigurableProductEntityTest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\ConfigurableProduct\Test\TestCase\CreateConfigurableProductEntityTest" summary="Create Configurable Product" ticketId="MAGETWO-26041">
+        <variation name="CreateConfigurableProductEntityTestVariation1" summary="Create product with category and two new options">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+        <variation name="CreateConfigurableProductEntityTestVariation2" summary="Create product with two options">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/TestCase/PageBuilderCreateDownloadableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/TestCase/PageBuilderCreateDownloadableProductEntityTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Downloadable\Test\TestCase\CreateDownloadableProductEntityTest" summary="Create Downloadable Product" ticketId="MAGETWO-23425">
+        <variation name="CreateDownloadableProductEntityTestVariation8" summary="Create product without tax class id">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>

--- a/dev/tests/functional/tests/app/Magento/PageBuilder/Mtf/App/State/PageBuilderHandler.php
+++ b/dev/tests/functional/tests/app/Magento/PageBuilder/Mtf/App/State/PageBuilderHandler.php
@@ -3,17 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
-declare(strict_types=1);
-
 namespace Magento\PageBuilder\Mtf\App\State;
 
 use Magento\Mtf\App\State\AbstractState;
 use Magento\Mtf\App\State\StateHandlerInterface;
 
-/**
- * MTF test observer for managing PageBuilder's state
- */
 class PageBuilderHandler implements StateHandlerInterface
 {
     /**
@@ -39,21 +33,7 @@ class PageBuilderHandler implements StateHandlerInterface
      */
     public function execute(AbstractState $state)
     {
-        $config = include BP . '/app/etc/config.php';
-        $moduleStatuses = $config['modules'];
-        $moduleNames = array_keys($moduleStatuses);
-
-        $enabledPageBuilderModuleNames = array_filter($moduleNames, function ($moduleName) use ($moduleStatuses) {
-            $isEnabled = (bool) $moduleStatuses[$moduleName];
-            $isPageBuilderRelatedModule = stripos($moduleName, 'PageBuilder') !== false;
-
-            return $isEnabled && $isPageBuilderRelatedModule;
-        });
-
-        // disable modules in reverse order of installation
-        foreach (array_reverse($enabledPageBuilderModuleNames) as $enabledPageBuilderModuleName) {
-            $this->configuration->execute('module:disable', [$enabledPageBuilderModuleName]);
-        }
+        $this->configuration->setConfig('cms/pagebuilder/enabled', '0');
 
         return true;
     }

--- a/dev/tests/functional/tests/app/Magento/PageBuilder/Test/etc/di.xml
+++ b/dev/tests/functional/tests/app/Magento/PageBuilder/Test/etc/di.xml
@@ -6,7 +6,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/Magento/Mtf/ObjectManager/etc/config.xsd">
-    <type name="Magento\Mtf\App\State\State1">
+    <type name="Magento\Mtf\App\State\AbstractState">
         <arguments>
             <argument name="arguments" xsi:type="array">
                 <item name="disable-page-builder" xsi:type="string">Magento\PageBuilder\Mtf\App\State\PageBuilderHandler</item>

--- a/dev/tests/functional/tests/app/Magento/Reports/Test/TestCase/PageBuilderProductsInCartReportEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Reports/Test/TestCase/PageBuilderProductsInCartReportEntityTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/etc/variations.xsd">
+    <testCase name="Magento\Reports\Test\TestCase\ProductsInCartReportEntityTest" summary="Products In Cart Report" ticketId="MAGETWO-27952">
+        <variation name="ProductsInCartReportEntityVariation1">
+            <data name="issue" xsi:type="string">MC-3294: MTF test from basic_green suite is broken for PB repository</data>
+        </variation>
+    </testCase>
+</config>


### PR DESCRIPTION
## Scope

### Bug
* [MC-15336](https://jira.corp.magento.com/browse/MC-15336): Revert MC-11044 to restore builds

### Jenkins
https://m2build-ur.devops.magento.com/job/Functional-Tests-EE-UR/14575/ (MTF + MFTF)

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by @davemacaulay 
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
- [ ] Pull Request QA review performed by @dhaecker

### Related Pull Request
https://github.com/magento/magento2-page-builder-ee/pull/55

### Notes
This reverts commit 0de08e5c9fae2e86240e186a8db280de6e45f623, reversing
changes made to 67eaaef37e10669b3354a63e794d898e9a5e0d8d.