### PR TITLE
Feature/native lazyloading

### DIFF
--- a/app/code/Magento/PageBuilder/Plugin/Filter/TemplatePlugin.php
+++ b/app/code/Magento/PageBuilder/Plugin/Filter/TemplatePlugin.php
@@ -16,6 +16,8 @@ class TemplatePlugin
 
     const HTML_CONTENT_TYPE_PATTERN = '/data-content-type="html"/si';
 
+    const INLINE_IMAGE_PATTERN = '/<img/si';
+
     /**
      * @var \Magento\Framework\View\ConfigInterface
      */
@@ -76,6 +78,12 @@ class TemplatePlugin
         if (preg_match(self::BACKGROUND_IMAGE_PATTERN, $result)) {
             $document = $this->getDomDocument($result);
             $this->generateBackgroundImageStyles($document);
+        }
+
+        // Process images to add native lazy loading
+        if (preg_match(self::INLINE_IMAGE_PATTERN, $result)) {
+            $document = $this->getDomDocument($result);
+            $uniqueNodeNameToDecodedOuterHtmlMap = $this->generateLazyImages($document);
         }
 
         // Process any HTML content types, they need to be decoded on the front-end
@@ -257,6 +265,21 @@ class TemplatePlugin
                     $node->setAttribute('class', $classes . $elementClass);
                 }
             }
+        }
+    }
+
+    /**
+     * Make images lazy loaded
+     *
+     * @param \DOMDocument $document
+     */
+    private function generateLazyImages(\DOMDocument $document) : void
+    {
+        $xpath = new \DOMXPath($document);
+        $imgs = $xpath->query('//img');
+
+        foreach ($imgs as $img) {
+            $img->setAttribute('loading', 'lazy');
         }
     }
 


### PR DESCRIPTION
Hello 👋 

I haven't contributed to Magento in any way before - I've read the guidelines but let me know if something is missing. 

This PR adds native lazy loading support to the images spat out by the Text block WYSIWYG. I'm using the same technique used to handle background images so parsing the document using `DOMDocument`. I don't know if this is necessarily the best place to do this.

That said - I've tested this and it works perfectly in Chrome 76. In non-supporting browsers, nothing happens, and images download as normal. Therefore, I consider this feature low-risk, but feel free to disagree.

Regarding a JavaScript fallback - there are some issues with this. Notably, the fallbacks suggested by developer advocates for Google mean a reliance on JavaScript. Open to thoughts and suggestions however. 