### PR TITLE
[Owls] PB-143: Remove invalid @api annotation from new controller

### DIFF
--- a/app/code/Magento/PageBuilder/Controller/Adminhtml/Stage/Preview.php
+++ b/app/code/Magento/PageBuilder/Controller/Adminhtml/Stage/Preview.php
@@ -13,8 +13,6 @@ use Magento\Framework\App\Action\HttpPostActionInterface;
 
 /**
  * Preview controller to render blocks preview on Stage
- *
- * @api
  */
 class Preview extends \Magento\Backend\App\Action implements HttpPostActionInterface
 {


### PR DESCRIPTION
We need to remove the `@api` annotation from the controller `app/code/Magento/PageBuilder/Controller/Adminhtml/Stage/Preview.php`. We cannot add new API's during patch versions.