### PR TITLE
Add min resolver to render after requirejs

### DIFF
--- a/app/code/Magento/PageBuilder/Block/Adminhtml/Stage/Render.php
+++ b/app/code/Magento/PageBuilder/Block/Adminhtml/Stage/Render.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Magento\PageBuilder\Block\Adminhtml\Stage;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\View\Asset\Minification;
 use Magento\Framework\View\Element\Template;
 use Magento\RequireJs\Model\FileManager;
 use Magento\PageBuilder\Model\Stage\Config;
@@ -34,23 +36,31 @@ class Render extends Template
     private $json;
 
     /**
+     * @var Minification
+     */
+    private $minification;
+
+    /**
      * @param Template\Context $context
      * @param FileManager $fileManager
      * @param Config $config
      * @param Json $json
      * @param array $data
+     * @param Minification $minification
      */
     public function __construct(
         Template\Context $context,
         FileManager $fileManager,
         Config $config,
         Json $json,
-        array $data = []
+        array $data = [],
+        Minification $minification = null
     ) {
         parent::__construct($context, $data);
         $this->fileManager = $fileManager;
         $this->pageBuilderConfig = $config;
         $this->json = $json;
+        $this->minification = $minification ?: ObjectManager::getInstance()->get(Minification::class);
     }
 
     /**
@@ -63,6 +73,20 @@ class Render extends Template
     {
         $asset = $this->_assetRepo->createAsset('requirejs/require.js');
         return $asset->getUrl();
+    }
+
+    /**
+     * Generate the URL to the RequireJS min resolver, if minification enabled.
+     *
+     * @return string|null
+     */
+    public function getRequireJsMinUrl() : ?string
+    {
+        if ($this->minification->isEnabled('js')) {
+            $minResolverAsset = $this->fileManager->createMinResolverAsset();
+            return $minResolverAsset->getUrl();
+        }
+        return null;
     }
 
     /**

--- a/app/code/Magento/PageBuilder/view/adminhtml/templates/stage/render.phtml
+++ b/app/code/Magento/PageBuilder/view/adminhtml/templates/stage/render.phtml
@@ -7,6 +7,9 @@
 /** @var \Magento\PageBuilder\Block\Adminhtml\Stage\Render $block */
 ?>
 <script src="<?= $block->escapeUrl($block->getRequireJsUrl()); ?>"></script>
+<?php if ($block->getRequireJsMinUrl()) : ?>
+<script src="<?= $block->escapeUrl($block->getRequireJsMinUrl()); ?>"></script>
+<?php endif; ?>
 <script src="<?= $block->escapeUrl($block->getRequireJsConfigUrl()); ?>"></script>
 <script>
     <?php


### PR DESCRIPTION
This is needed for editing to work while minification is enabled.  Otherwise, it attempts to load bad URLs that won't exist.

Note: this must be after require.min.js.

STR:
1. Enable js minification (ideally via config.php.)
2. It's imperative that you enable production mode.  This does not reproduce in developer mode, because obviously js minification is auto-disabled in developer mode.
3. Go to the CMS pages section, and click "Add New Page".
4. Expand the Content section.  You'll already notice JS errors in the console, if you're looking.
5. Drag a "Text" content type from the Elements section into the main area.
6. Type any content, such as "Hello world".
7. Click Save in the top right.

Actual behavior: does not save.  Spinner spins forever.
Expected behavior: save completes.

See also Magento support 252229.

This change is needed on 2.3.2-p2 and appears to be needed on 2.3.3 as well.

Note: partner contribution from Something Digital.