### PR TITLE
PB-199: Failing MFTF Test: ReadHtmlWithNewImage

### DIFF
--- a/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderReadNonMasterFormatTest.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderReadNonMasterFormatTest.xml
@@ -225,6 +225,9 @@
         <click selector="{{MediaGallerySection.Browse}}" stepKey="clickBrowse" />
         <waitForPageLoad stepKey="waitForPageLoad2" />
         <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear1" />
+        <actionGroup ref="NavigateToMediaFolderActionGroup" stepKey="navigateToStorageRootFolder">
+            <argument name="FolderName" value="Storage Root"/>
+        </actionGroup>
         <click selector="{{MediaGallerySection.CreateFolder}}" stepKey="createFolder"/>
         <waitForElementVisible selector="{{MediaGallerySection.FolderName}}" stepKey="waitForPopup" />
         <fillField selector="{{MediaGallerySection.FolderName}}" userInput="{{ImageFolder.name}}" stepKey="fillFolderName" />


### PR DESCRIPTION
## Scope
### Bugs
* [PB-199](https://jira.corp.magento.com/browse/PB-199): Failing MFTF Test: ReadHtmlWithNewImage

### Jenkins Builds
* https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/25986/
* https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/26006/
* https://m2build-ur-4.devops.magento.com/job/All-User-Requested-Tests/204/
* https://m2build-ur-4.devops.magento.com/job/All-User-Requested-Tests/208/

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Pull Request approved by architect (optional)
- [ ] Pull Request quality review performed by @davemacaulay
- [ ] Pull Request QA review performed by @dhaecker
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] [Jenkins Extended FAT build is green]