### PR TITLE
PB-215: Remove docs link

### DIFF
--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -38,7 +38,7 @@ The following table lists the Page Builder events you can bind to and handle wit
 | **Column Events**                                   | **Preview Events**                                       |
 | [column:dragStart](#columndragstart)                | [childContentType:sortstart](#childcontenttypesortstart)                                |
 | [column:dragStop](#columndragstop)                  | [childContentType:sortupdate](#childcontenttypesortupdate)                               |
-| [column:initializeAfter](#columninitializeafter)    | [previewData:updateAfter](#previewdataupdateafter)                                  |
+| [column:initializeAfter](#columninitializeafter)    |                                   |
 |                                                     |                                                          |
 | **Image Events**                                    | **Other Events**                                         |
 | [image:{{preview.contentType.id}}:assignAfter](#imageidassignafter) | [googleMaps:authFailure](#googlemapsauthfailure)                                   |


### PR DESCRIPTION
# Scope

## Bugs
**PB-215:**: Remove docs link

## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Fixes a broken documentation link in the `events.md` file due to the removal of the  `previewData:updateAfter` section within the PB-77 story. This is significant and urgent to fix because the link checker on all devdocs builds will fail because of how multi-repos are built with every devdocs build.