### PR TITLE
[Owls] PB-223 Enable strict mode for template filtering (1.2.0)

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Stage/Renderer/WidgetDirective.php
+++ b/app/code/Magento/PageBuilder/Model/Stage/Renderer/WidgetDirective.php
@@ -67,9 +67,11 @@ class WidgetDirective implements \Magento\PageBuilder\Model\Stage\RendererInterf
         }
 
         try {
+            $previousStrictMode = $this->directiveFilter->setStrictMode(true);
             $result['content'] = $this->directiveFilter
                 ->setStoreId(Store::DEFAULT_STORE_ID)
                 ->filter($this->templateFilter->filter($params['directive']));
+            $this->directiveFilter->setStrictMode($previousStrictMode);
         } catch (\Exception $e) {
             $result['error'] = __($e->getMessage());
         }


### PR DESCRIPTION
## Scope

### Bug
* [PB-223](https://jira.corp.magento.com/browse/PB-223) Enable strict mode for template filtering

### Builds
[All-User-Requested-Tests](https://m2build-ur-4.devops.magento.com/job/All-User-Requested-Tests/290/)


### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
