### PR TITLE
[Owls] PB-285: Remove 200ms delay from options menu & toolbar on content types

### DIFF
--- a/app/code/Magento/PageBuilder/Test/Mftf/ActionGroup/OptionsMenuActionGroup.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/ActionGroup/OptionsMenuActionGroup.xml
@@ -113,6 +113,7 @@
         <waitForElementVisible selector="{{PageBuilderStage.contentTypeInStageByIndex(contentType.role, targetIndex)}}" stepKey="waitForContentTypeInStageVisible"/>
         <moveMouseOver selector="{{PageBuilderStage.contentTypeInStageByIndex(contentType.role, targetIndex)}}" x="{{contentTypeXCoordinate}}" y="{{contentTypeYCoordinate}}" stepKey="onMouseOverContentTypeStage"/>
         <waitForElementVisible selector="{{PageBuilderContentTypeOptionsMenu.contentTypeOptionsMenuByIndex(contentType.role, targetIndex)}}" stepKey="waitForOptionsMenu"/>
+        <waitForElementVisible selector="{{PageBuilderContentTypeOptionsMenu.contentTypeDuplicate(contentType.role, targetIndex)}}" stepKey="waitForDuplicate"/>
         <click selector="{{PageBuilderContentTypeOptionsMenu.contentTypeDuplicate(contentType.role, targetIndex)}}" stepKey="clickDuplicateContentType"/>
         <waitForPageLoad time="30" stepKey="waitForAnimation"/>
         <executeJS function="return document.querySelectorAll('{{PageBuilderStage.contentTypeTotalInStage(contentType.role)}}').length" stepKey="resultingContentTypeCount"/>

--- a/app/code/Magento/PageBuilder/Test/Mftf/ActionGroup/StageActionGroup.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/ActionGroup/StageActionGroup.xml
@@ -131,22 +131,42 @@
         <arguments>
             <argument name="section" defaultValue="TextOnStage"/>
             <argument name="index" defaultValue="1" type="string"/>
+            <argument name="contentTypeXCoordinate" defaultValue="0" type="string"/>
+            <argument name="contentTypeYCoordinate" defaultValue="0" type="string"/>
         </arguments>
         <comment userInput="focusOnInlineTinyMCEEditor" stepKey="comment"/>
         <waitForElementVisible selector="{{section.tinymce(index)}}" stepKey="waitForEditor"/>
-        <click selector="{{section.tinymce(index)}}" stepKey="clickEditor"/>
+        <clickWithLeftButton selector="{{section.tinymce(index)}}" x="{{contentTypeXCoordinate}}" y="{{contentTypeYCoordinate}}" stepKey="clickEditor"/>
         <waitForPageLoad stepKey="waitForEditorToBeFocused"/>
         <waitForElementVisible selector="{{section.tinymceInFocus(index)}}" stepKey="waitForEditorFocused"/>
+    </actionGroup>
+    <actionGroup name="goToEndOfLineTinyMCEEditor">
+        <arguments>
+            <argument name="section" defaultValue="TextOnStage"/>
+            <argument name="index" defaultValue="1" type="string"/>
+        </arguments>
+        <waitForElementVisible selector="{{section.tinymce(index)}}" stepKey="waitForEditor"/>
+        <pressKey selector="{{section.tinymce(index)}}" parameterArray="[\Facebook\WebDriver\WebDriverKeys::END]" stepKey="pressEndKey"/>
     </actionGroup>
     <actionGroup name="focusOnInlineTextAreaEditor">
         <arguments>
             <argument name="section" defaultValue="TextOnStage"/>
             <argument name="index" defaultValue="1" type="string"/>
+            <argument name="contentTypeXCoordinate" defaultValue="0" type="string"/>
+            <argument name="contentTypeYCoordinate" defaultValue="0" type="string"/>
         </arguments>
         <comment userInput="focusOnInlineTextAreaEditor" stepKey="comment"/>
         <waitForElementVisible selector="{{section.textArea(index)}}" stepKey="waitForEditor"/>
-        <click selector="{{section.textArea(index)}}" stepKey="clickEditor"/>
+        <clickWithLeftButton selector="{{section.textArea(index)}}" x="{{contentTypeXCoordinate}}" y="{{contentTypeYCoordinate}}" stepKey="clickEditor"/>
         <waitForPageLoad stepKey="waitForEditorToBeFocused"/>
+    </actionGroup>
+    <actionGroup name="goToEndOfLineTextAreaEditor">
+        <arguments>
+            <argument name="section" defaultValue="TextOnStage"/>
+            <argument name="index" defaultValue="1" type="string"/>
+        </arguments>
+        <waitForElementVisible selector="{{section.textArea(index)}}" stepKey="waitForEditor"/>
+        <pressKey selector="{{section.textArea(index)}}" parameterArray="[\Facebook\WebDriver\WebDriverKeys::END]" stepKey="pressEndKey"/>
     </actionGroup>
     <actionGroup name="switchTabAndReloadPage">
         <switchToNextTab stepKey="switchToNextTab"/>

--- a/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderBlockRenderElementContentTypesTests.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderBlockRenderElementContentTypesTests.xml
@@ -144,6 +144,7 @@
         <!-- Inline Edit: Add Text -->
         <comment userInput="Inline Edit: Add Text" stepKey="commentInlineEditAddText"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor"/>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd"/>
         <actionGroup ref="addTextToTinyMCEInline" stepKey="addTextToTinyMCEInline">
             <argument name="section" value="TextOnStage"/>
             <argument name="text" value="{{PageBuilderTextProperty.value}}"/>
@@ -151,12 +152,14 @@
         <!-- Inline Edit: Add Variable -->
         <comment userInput="Inline Edit: Add Variable" stepKey="commentInlineEditAddVariable"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor2"/>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd2"/>
         <actionGroup ref="addVariableToTinyMCEInline" stepKey="addVariableToTinyMCE">
             <argument name="variable" value="TinyMCEVariableBaseURL"/>
         </actionGroup>
         <!-- Inline Edit: Add Widget -->
         <comment userInput="Inline Edit: Add Widget" stepKey="commentInlineEditAddWidget"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor3"/>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd3"/>
         <actionGroup ref="addPageLinkWidgetToTinyMCEInline" stepKey="addPageLinkWidgetToTinyMCE">
             <argument name="widget" value="TinyMCEWidgetCMSPageLink"/>
             <argument name="page" value="$$createPreReqCMSPage.identifier$$"/>
@@ -164,6 +167,7 @@
         <!-- Inline Edit: Add Image -->
         <comment userInput="Inline Edit: Add Image" stepKey="commentInlineEditAddImage"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor4"/>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd4"/>
         <actionGroup ref="clickInsertImageInTinyMCE" stepKey="clickInsertImageInTinyMCE"/>
         <actionGroup ref="clickBrowseBtnOnUploadPopup" stepKey="clickBrowserBtn"/>
         <actionGroup ref="VerifyMediaGalleryStorageActions" stepKey="VerifyMediaGalleryStorageBtn"/>
@@ -315,7 +319,15 @@
         <comment userInput="Validate CMS Block Stage" stepKey="commentValidateCMSBlockStage"/>
         <actionGroup ref="assertTextareaContainsValue" stepKey="assertTextareaContainsValueCMSBlockStage">
             <argument name="selector" value="{{TextOnStage.textArea('1')}}"/>
-            <argument name="value" value="{{PageBuilderTextProperty.value}}{{PageBuilderTextArea_VariableBaseURL.editPanelValue}}{{PageBuilderTextArea_WidgetCMSHomepageLink.editPanelValue}}"/>
+            <argument name="value" value="{{PageBuilderTextProperty.value}}"/>
+        </actionGroup>
+        <actionGroup ref="assertTextareaContainsValue" stepKey="assertTextareaContainsValueCMSBlockStage2">
+            <argument name="selector" value="{{TextOnStage.textArea('1')}}"/>
+            <argument name="value" value="{{PageBuilderTextArea_VariableBaseURL.editPanelValue}}"/>
+        </actionGroup>
+        <actionGroup ref="assertTextareaContainsValue" stepKey="assertTextareaContainsValueCMSBlockStage3">
+            <argument name="selector" value="{{TextOnStage.textArea('1')}}"/>
+            <argument name="value" value="{{PageBuilderTextArea_WidgetCMSHomepageLink.editPanelValue}}"/>
         </actionGroup>
         <!-- Add Block to CMS Page -->
         <comment userInput="Add Block to CMS Page" stepKey="commentAddBlockToCMSPage"/>

--- a/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderBlockRenderMediaContentTypesTests.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderBlockRenderMediaContentTypesTests.xml
@@ -905,6 +905,9 @@
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor">
             <argument name="section" value="BannerOnBackend"/>
         </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd">
+            <argument name="section" value="BannerOnBackend"/>
+        </actionGroup>
         <actionGroup ref="addTextToTinyMCEInline" stepKey="addTextToTinyMCEInline">
             <argument name="section" value="BannerOnBackend"/>
             <argument name="text" value="{{PageBuilderBannerMessageProperty.value}}"/>
@@ -912,6 +915,9 @@
         <!-- Inline Edit: Add Variable -->
         <comment userInput="Inline Edit: Add Variable" stepKey="commentInlineEditAddVariable"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor2">
+            <argument name="section" value="BannerOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd2">
             <argument name="section" value="BannerOnBackend"/>
         </actionGroup>
         <actionGroup ref="addVariableToTinyMCEInline" stepKey="addVariableToTinyMCE">
@@ -922,6 +928,9 @@
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor3">
             <argument name="section" value="BannerOnBackend"/>
         </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd3">
+            <argument name="section" value="BannerOnBackend"/>
+        </actionGroup>
         <actionGroup ref="addPageLinkWidgetToTinyMCEInline" stepKey="addPageLinkWidgetToTinyMCE">
             <argument name="widget" value="TinyMCEWidgetCMSPageLink"/>
             <argument name="page" value="$$createPreReqCMSPage.identifier$$"/>
@@ -929,6 +938,9 @@
         <!-- Inline Edit: Add Image -->
         <comment userInput="Inline Edit: Add Image" stepKey="commentInlineEditAddImage"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor4">
+            <argument name="section" value="BannerOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd4">
             <argument name="section" value="BannerOnBackend"/>
         </actionGroup>
         <actionGroup ref="clickInsertImageInTinyMCE" stepKey="clickInsertImageInTinyMCE"/>
@@ -1064,12 +1076,18 @@
         <actionGroup ref="focusOnInlineTextAreaEditor" stepKey="focusOnInlineTextAreaEditor">
             <argument name="section" value="BannerOnBackend"/>
         </actionGroup>
+        <actionGroup ref="goToEndOfLineTextAreaEditor" stepKey="goToEndOfLine">
+            <argument name="section" value="BannerOnBackend"/>
+        </actionGroup>
         <actionGroup ref="addTextToTinyMCEInlineWYSIWYGDisabled" stepKey="addTextToTinyMCEInline">
             <argument name="section" value="BannerOnBackend"/>
             <argument name="text" value="{{PageBuilderBannerMessageProperty.value}}"/>
         </actionGroup>
         <!-- Inline Edit: Add Variable -->
         <actionGroup ref="focusOnInlineTextAreaEditor" stepKey="focusOnInlineTextAreaEditor2">
+            <argument name="section" value="BannerOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTextAreaEditor" stepKey="goToEndOfLine2">
             <argument name="section" value="BannerOnBackend"/>
         </actionGroup>
         <actionGroup ref="addTextToTinyMCEInlineWYSIWYGDisabled" stepKey="addVariableToTinyMCE">
@@ -1079,6 +1097,9 @@
         <!-- Inline Edit: Add Widget -->
         <comment userInput="Inline Edit: Add Widget" stepKey="commentInlineEditAddWidget"/>
         <actionGroup ref="focusOnInlineTextAreaEditor" stepKey="focusOnInlineTextAreaEditor3">
+            <argument name="section" value="BannerOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTextAreaEditor" stepKey="goToEndOfLine3">
             <argument name="section" value="BannerOnBackend"/>
         </actionGroup>
         <actionGroup ref="addTextToTinyMCEInlineWYSIWYGDisabled" stepKey="addPageLinkWidgetToTinyMCE">
@@ -1169,6 +1190,9 @@
         <!-- Edit Slide 1 -->
         <comment userInput="Edit Slide 1" stepKey="commentEditSlide1"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
         <actionGroup ref="addTextToTinyMCEInline" stepKey="addTextToTinyMCEInline">
@@ -1803,6 +1827,9 @@
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
         <actionGroup ref="addTextToTinyMCEInline" stepKey="addTextToTinyMCEInline">
             <argument name="section" value="SlideOnBackend"/>
             <argument name="text" value="{{PageBuilderSlideItemContent_Slide1.value}}"/>
@@ -1810,6 +1837,9 @@
         <!-- Inline Edit: Add Variable -->
         <comment userInput="Inline Edit: Add Variable" stepKey="commentInlineEditAddVariable"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor2">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd2">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
         <actionGroup ref="addVariableToTinyMCEInline" stepKey="addVariableToTinyMCE">
@@ -1820,6 +1850,9 @@
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor3">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd3">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
         <actionGroup ref="addPageLinkWidgetToTinyMCEInline" stepKey="addPageLinkWidgetToTinyMCE">
             <argument name="widget" value="TinyMCEWidgetCMSPageLink"/>
             <argument name="page" value="$$createPreReqCMSPage.identifier$$"/>
@@ -1827,6 +1860,9 @@
         <!-- Inline Edit: Add Image -->
         <comment userInput="Inline Edit: Add Image" stepKey="commentInlineEditAddImage"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor4">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd4">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
         <actionGroup ref="clickInsertImageInTinyMCE" stepKey="clickInsertImageInTinyMCE"/>
@@ -1845,6 +1881,9 @@
         <!-- Validate CMS Block Stage -->
         <comment userInput="Validate CMS Block Stage" stepKey="commentValidateCMSBlockStage"/>
         <actionGroup ref="focusOnInlineTinyMCEEditor" stepKey="focusOnInlineTinyMCEEditor5">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTinyMCEEditor" stepKey="moveCaretToEnd5">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
         <seeElement selector="{{SlideOnBackend.messageContent('1', PageBuilderSlideItemContent_Slide1.value)}}" stepKey="seeTextCMSBlockStage"/>
@@ -1965,12 +2004,18 @@
         <actionGroup ref="focusOnInlineTextAreaEditor" stepKey="focusOnInlineTextAreaEditor">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
+        <actionGroup ref="goToEndOfLineTextAreaEditor" stepKey="goToEndOfLine">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
         <actionGroup ref="addTextToTinyMCEInlineWYSIWYGDisabled" stepKey="addTextToTinyMCEInline">
             <argument name="section" value="SlideOnBackend"/>
             <argument name="text" value="{{PageBuilderSlideItemContent_Slide1.value}}"/>
         </actionGroup>
         <!-- Inline Edit: Add Variable -->
         <actionGroup ref="focusOnInlineTextAreaEditor" stepKey="focusOnInlineTextAreaEditor2">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTextAreaEditor" stepKey="goToEndOfLine2">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
         <actionGroup ref="addTextToTinyMCEInlineWYSIWYGDisabled" stepKey="addVariableToTinyMCE">
@@ -1980,6 +2025,9 @@
         <!-- Inline Edit: Add Widget -->
         <comment userInput="Inline Edit: Add Widget" stepKey="commentInlineEditAddWidget"/>
         <actionGroup ref="focusOnInlineTextAreaEditor" stepKey="focusOnInlineTextAreaEditor3">
+            <argument name="section" value="SlideOnBackend"/>
+        </actionGroup>
+        <actionGroup ref="goToEndOfLineTextAreaEditor" stepKey="goToEndOfLine3">
             <argument name="section" value="SlideOnBackend"/>
         </actionGroup>
         <actionGroup ref="addTextToTinyMCEInlineWYSIWYGDisabled" stepKey="addPageLinkWidgetToTinyMCE">

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/css/source/_toolbar.less
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/css/source/_toolbar.less
@@ -19,7 +19,6 @@
 
     .pagebuilder-toolbar-options {
         opacity: 1;
-        transition-delay: 200ms;
         visibility: visible;
     }
 }

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/css/source/content-type/_preview.less
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/css/source/content-type/_preview.less
@@ -318,7 +318,6 @@
 
 .pagebuilder-options-visible {
     opacity: 1;
-    transition-delay: 200ms;
     visibility: visible;
 }
 
@@ -468,7 +467,6 @@
         top: -20px;
         transform: translate(50%, -50%);
         transition: opacity 200ms, visibility 200ms, transform 200ms;
-        transition-delay: 0ms !important; // Arrow options have no delay in transitioning out
 
         .pagebuilder-options-wrapper {
             &:after {


### PR DESCRIPTION
## Scope
### Bug
* [PB-285](https://jira.corp.magento.com/browse/PB-285) Remove 200ms delay from options menu & toolbar on content types

### Builds
https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/27045/

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
