### PR TITLE
[Owls] PB-294: Currency Symbol Escaping Improperly in Product List Widget in Block/Dynamic Block on Admin

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Stage/HtmlFilter.php
+++ b/app/code/Magento/PageBuilder/Model/Stage/HtmlFilter.php
@@ -40,11 +40,12 @@ class HtmlFilter
      */
     public function filterHtml(string $content): string
     {
-        $dom = new \DOMDocument();
+        $dom = new \DOMDocument('1.0', 'UTF-8');
         try {
             //this code is required because of https://bugs.php.net/bug.php?id=60021
             $previous = libxml_use_internal_errors(true);
-            $dom->loadHTML($content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+            $string = mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8');
+            $dom->loadHTML($string, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         } catch (\Exception $e) {
             $this->loggerInterface->critical($e->getMessage());
         }


### PR DESCRIPTION
## Scope
### Bug
* [PB-294](https://jira.corp.magento.com/browse/PB-294) Currency Symbol Escaping Improperly in Product List Widget in Block/Dynamic Block on Admin
* #305 

### Builds
https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/27156/

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
