### PR TITLE
[Owls] PB-315 [PB-1.1.1 Backport] Products lose their conditions after upgrade

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/products/mass-converter/widget-directive.js
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/products/mass-converter/widget-directive.js
@@ -56,10 +56,13 @@ define(["Magento_PageBuilder/js/mass-converter/widget-directive-abstract", "Mage
         id_path: "",
         show_pager: 0,
         products_count: data.products_count,
-        sort_order: data.sort_order,
         type_name: "Catalog Products List",
         conditions_encoded: this.encodeWysiwygCharacters(data.conditions_encoded || "")
       };
+
+      if (data.sort_order) {
+        attributes.sort_order = data.sort_order;
+      }
 
       if (attributes.conditions_encoded.length === 0) {
         return data;

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/ts/js/content-type/products/mass-converter/widget-directive.ts
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/ts/js/content-type/products/mass-converter/widget-directive.ts
@@ -46,10 +46,13 @@ export default class WidgetDirective extends BaseWidgetDirective {
             id_path: "",
             show_pager: 0,
             products_count: data.products_count,
-            sort_order: data.sort_order,
             type_name: "Catalog Products List",
             conditions_encoded: this.encodeWysiwygCharacters(data.conditions_encoded || ""),
-        };
+        } as { [key: string]: any; };
+
+        if (data.sort_order) {
+            attributes.sort_order = data.sort_order;
+        }
 
         if (attributes.conditions_encoded.length === 0) {
             return data;

--- a/dev/tests/js/jasmine/tests/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/products/mass-converter/widget-directive.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/products/mass-converter/widget-directive.test.js
@@ -69,7 +69,8 @@ define([
             it('Should transform regular properties', function () {
                 var data = {
                         products_count: 123,
-                        conditions_encoded: '[]'
+                        conditions_encoded: '[]',
+                        sort_order: 'date_newest_top'
                     },
                     config = {
                         html_variable: 'myhtml'
@@ -85,6 +86,7 @@ define([
                 expect(result.myhtml).toContain(' id_path=""');
                 expect(result.myhtml).toContain(' show_pager="0"');
                 expect(result.myhtml).toContain(' type_name="Catalog Products List"');
+                expect(result.myhtml).toContain(' sort_order="date_newest_top');
             });
             it('Should encode conditions_encoded', function () {
                 var data = {
@@ -104,6 +106,18 @@ define([
                 expect(result.myhtml).toContain(' id_path=""');
                 expect(result.myhtml).toContain(' show_pager="0"');
                 expect(result.myhtml).toContain(' type_name="Catalog Products List"');
+            });
+            it('Should not add empty sort_order attribute', function () {
+                var data = {
+                        products_count: 123,
+                        conditions_encoded: '[]'
+                    },
+                    config = {
+                        html_variable: 'myhtml'
+                    },
+                    result = model.toDom(data, config);
+
+                expect(result.myhtml).not.toContain('sort_order');
             });
         });
         describe('fromDom', function () {


### PR DESCRIPTION
### Bug
* [PB-315](https://jira.corp.magento.com/browse/PB-315) [PB-1.1.1 Backport] Products lose their conditions after upgrade

### Builds
https://m2build-ur-4.devops.magento.com/job/All-User-Requested-Tests/337/

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
