### PR TITLE
Fix config.media_url is resolved to admin base url instead of frontend base url

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Stage/Config.php
+++ b/app/code/Magento/PageBuilder/Model/Stage/Config.php
@@ -134,7 +134,7 @@ class Config
             'menu_sections' => $this->getMenuSections(),
             'content_types' => $this->getContentTypes(),
             'stage_config' => $this->data,
-            'media_url' => $this->urlBuilder->getBaseUrl(['_type' => UrlInterface::URL_TYPE_MEDIA]),
+            'media_url' => $this->frontendUrlBuilder->getBaseUrl(['_type' => UrlInterface::URL_TYPE_MEDIA]),
             'preview_url' => $this->urlBuilder->getUrl('pagebuilder/stage/preview'),
             'render_url' => $this->urlBuilder->getUrl('pagebuilder/stage/render'),
             'column_grid_default' => $this->scopeConfig->getValue(self::XML_PATH_COLUMN_GRID_DEFAULT),


### PR DESCRIPTION
## Scope
### Bug
* [MC-29462](https://jira.corp.magento.com/browse/MC-29462) Uploaded Image in CMS block using PageBuilder does not show up in the preview when the admin url is on a different domain
### Builds
[All-User-Requested-Tests](https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/27382/)
### Related Pull Requests
<!--- 
https://github.com/magento/magento2ce/pull/<related_pr>
-->
<!-- related pull request placeholder -->

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
