### PR TITLE
[Support] MC-30156: Fix return value of Magento\PageBuilder\Model\Stage\Preview::isPreviewMode() must be of the type boolean, null returned

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Stage/Preview.php
+++ b/app/code/Magento/PageBuilder/Model/Stage/Preview.php
@@ -43,6 +43,11 @@ class Preview
     private $scopeConfig;
 
     /**
+     * @var bool
+     */
+    private $isPreview = false;
+
+    /**
      * Preview constructor.
      * @param \Magento\Store\Model\App\Emulation $emulation
      * @param \Magento\Framework\App\State $appState
@@ -66,11 +71,6 @@ class Preview
         $this->storeManager = $storeManager;
         $this->scopeConfig = $scopeConfig;
     }
-
-    /**
-     * @var bool
-     */
-    private $isPreview;
 
     /**
      * Retrieve the area in which the preview needs to be ran in


### PR DESCRIPTION
## Scope
### Bug
* [MC-30156](https://jira.corp.magento.com/browse/MC-30156) [Magento Cloud] - Indexer Error happens after appled a patch

### Builds
[All-User-Requested-Tests](https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/27941)

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
