### PR TITLE
Update Preview.php

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Stage/Preview.php
+++ b/app/code/Magento/PageBuilder/Model/Stage/Preview.php
@@ -129,6 +129,6 @@ class Preview
      */
     public function isPreviewMode() : bool
     {
-        return $this->isPreview;
+        return (bool) $this->isPreview;
     }
 }


### PR DESCRIPTION
Under certain circumstances isPreviewMode will return null instead of true or false

## Scope
### Story
<!--- 
* [<issue_number>](https://jira.corp.magento.com/browse/<issue_number>) <issue_title>
-->

### Bug
<!--- 
* [<issue_number>](https://jira.corp.magento.com/browse/<issue_number>) <issue_title>
-->
When you use smile elasticsuite cms page fulltext with magento 2.3.4 the indexer will stop with this error:

PHP Fatal error:  Uncaught TypeError: Return value of Magento\PageBuilder\Model\Stage\Preview::isPreviewMode() must be of the type boolean, null returned in vendor/magento/module-page-builder/Model/Stage/Preview.php:132

The reason for this is a missing type casting in the page builder extension.

### Task
<!--- 
* [<issue_number>](https://jira.corp.magento.com/browse/<issue_number>) <issue_title>
-->

### Builds
<!--- 
[All-User-Requested-Tests](https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/<build_number>)
-->

### Related Pull Requests
<!--- 
https://github.com/magento/magento2ce/pull/<related_pr>
-->
<!-- related pull request placeholder -->

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
