### PR TITLE
[Owls] Fix copy & paste failing test in PageBuilder static tests

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcpd/blacklist/pagebuilder.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcpd/blacklist/pagebuilder.txt
@@ -1,1 +1,1 @@
-Magento/PageBuilder/Model/ResourceModel/Template/Grid/Collection
+Magento/PageBuilder/Model/ResourceModel/Template/Grid


### PR DESCRIPTION
## Scope
### Bug
* [PB-457](https://jira.corp.magento.com/browse/PB-457) Fix copy & paste failing test in PageBuilder static tests

<!--- 
### Related Pull Requests
https://github.com/magento/magento2ce/pull/<related_pr>
-->
<!-- related pull request placeholder -->

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
