### PR TITLE
PB-525: [2.3.6][Integration] Test Magento.CatalogPageBuilder.Model.Catalog.SortingTest.testSortOptions

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Catalog/Sorting/Price.php
+++ b/app/code/Magento/PageBuilder/Model/Catalog/Sorting/Price.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\PageBuilder\Model\Catalog\Sorting;
+
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Phrase;
+
+/**
+ * Sort catalog products by price
+ */
+class Price implements OptionInterface
+{
+    /**
+     * @var string
+     */
+    private $label;
+
+    /**
+     * @var string
+     */
+    private $sortDirection;
+
+    /**
+     * @var string
+     */
+    private $secondarySortDirection;
+
+    /**
+     * @param string $label
+     * @param string $sortDirection
+     * @param string $secondarySortDirection
+     */
+    public function __construct(
+        string $label,
+        string $sortDirection = Select::SQL_ASC,
+        ?string $secondarySortDirection = null
+    ) {
+        $this->label = $label;
+        $this->sortDirection = $sortDirection;
+        $this->secondarySortDirection = $secondarySortDirection ?? $sortDirection;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sort(Collection $collection): Collection
+    {
+        $collection->getSelect()->reset(Select::ORDER);
+        if ($collection->getLimitationFilters()->isUsingPriceIndex()) {
+            $collection->getSelect()->order("price_index.min_price $this->sortDirection");
+        } else {
+            $collection->addAttributeToSort('price', $this->sortDirection);
+        }
+        $collection->addAttributeToSort('entity_id', $this->secondarySortDirection);
+        return $collection;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLabel(): Phrase
+    {
+        return __($this->label);
+    }
+}

--- a/app/code/Magento/PageBuilder/Ui/DataProvider/Product/ProductCollection.php
+++ b/app/code/Magento/PageBuilder/Ui/DataProvider/Product/ProductCollection.php
@@ -29,13 +29,4 @@ class ProductCollection extends \Magento\Catalog\Model\ResourceModel\Product\Col
 
         return $this;
     }
-
-    /**
-     * @inheritdoc
-     */
-    protected function _productLimitationJoinPrice()
-    {
-        $this->_productLimitationFilters->setUsePriceIndex($this->getStoreId() !== Store::DEFAULT_STORE_ID);
-        return $this->_productLimitationPrice(false);
-    }
 }

--- a/app/code/Magento/PageBuilder/etc/di.xml
+++ b/app/code/Magento/PageBuilder/etc/di.xml
@@ -236,14 +236,12 @@
         <arguments>
             <argument name="label" xsi:type="string">Price: high to low</argument>
             <argument name="sortDirection" xsi:type="const">\Magento\Framework\DB\Select::SQL_DESC</argument>
-            <argument name="attributeField" xsi:type="string">price</argument>
         </arguments>
     </virtualType>
     <virtualType name="Magento\PageBuilder\Model\Catalog\Sorting\Price\LowToHigh" type="Magento\PageBuilder\Model\Catalog\Sorting\SimpleOption">
         <arguments>
             <argument name="label" xsi:type="string">Price: low to high</argument>
             <argument name="sortDirection" xsi:type="const">\Magento\Framework\DB\Select::SQL_ASC</argument>
-            <argument name="attributeField" xsi:type="string">price</argument>
         </arguments>
     </virtualType>
     <virtualType name="Magento\PageBuilder\Model\Catalog\Sorting\Position" type="Magento\PageBuilder\Model\Catalog\Sorting\SimpleOption">
@@ -259,6 +257,18 @@
             <argument name="label" xsi:type="string">Position</argument>
         </arguments>
     </virtualType>
+    <virtualType name="Magento\PageBuilder\Model\Catalog\Sorting\Price\Descending" type="Magento\PageBuilder\Model\Catalog\Sorting\Price">
+        <arguments>
+            <argument name="label" xsi:type="string">Price: high to low</argument>
+            <argument name="sortDirection" xsi:type="const">\Magento\Framework\DB\Select::SQL_DESC</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Magento\PageBuilder\Model\Catalog\Sorting\Price\Ascending" type="Magento\PageBuilder\Model\Catalog\Sorting\Price">
+        <arguments>
+            <argument name="label" xsi:type="string">Price: low to high</argument>
+            <argument name="sortDirection" xsi:type="const">\Magento\Framework\DB\Select::SQL_ASC</argument>
+        </arguments>
+    </virtualType>
     <type name="Magento\PageBuilder\Model\Catalog\Sorting">
         <arguments>
             <argument name="sortClasses" xsi:type="array">
@@ -272,8 +282,8 @@
                 <item name="sku_descending" xsi:type="string">Magento\PageBuilder\Model\Catalog\Sorting\Sku\Descending</item>
                 <item name="low_stock_first" xsi:type="string">Magento\PageBuilder\Model\Catalog\Sorting\Stock\Ascending</item>
                 <item name="high_stock_first" xsi:type="string">Magento\PageBuilder\Model\Catalog\Sorting\Stock\Descending</item>
-                <item name="price_high_to_low" xsi:type="string">Magento\PageBuilder\Model\Catalog\Sorting\Price\HighToLow</item>
-                <item name="price_low_to_high" xsi:type="string">Magento\PageBuilder\Model\Catalog\Sorting\Price\LowToHigh</item>
+                <item name="price_high_to_low" xsi:type="string">Magento\PageBuilder\Model\Catalog\Sorting\Price\Descending</item>
+                <item name="price_low_to_high" xsi:type="string">Magento\PageBuilder\Model\Catalog\Sorting\Price\Ascending</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
## Scope
### Bug
* [PB-525](https://jira.corp.magento.com/browse/PB-525) [2.3.6][Integration] Test Magento.CatalogPageBuilder.Model.Catalog.SortingTest.testSortOptions with data set #0 fails on Jenkins


### Related Pull Requests
https://github.com/magento/magento2-page-builder-ee/pull/139
<!-- related pull request placeholder -->

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
