### PR TITLE
Update function signature to match interface

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Dom/NodeList.php
+++ b/app/code/Magento/PageBuilder/Model/Dom/NodeList.php
@@ -44,7 +44,7 @@ class NodeList implements NodeListInterface
     /**
      * @inheritDoc
      */
-    public function item($index): ?ElementInterface
+    public function item(int $index): ?ElementInterface
     {
         return $this->objectManager->create(ElementInterface::class, [ 'element' => $this->nodeList->item($index) ]);
     }


### PR DESCRIPTION
### Description

`Magento\PageBuilder\Model\Dom\NodeList` implements `Magento\PageBuilder\Model\Dom\Adapter\NodeListInterface`, but the function signatures do not match for `::item()`.

When running `php bin/magento setup:di:compile` the following error is thrown:

> Compilation was started.
Repositories code generation... 1/8 [===>------------------------]  12% 1 sec 100.0 MiBPHP Fatal error:  Declaration of Magento\PageBuilder\Model\Dom\NodeList::item($index): ?Magento\PageBuilder\Model\Dom\Adapter\ElementInterface must be compatible with Magento\PageBuilder\Model\Dom\Adapter\NodeListInterface::item(int $index): ?Magento\PageBuilder\Model\Dom\Adapter\ElementInterface in /var/www/html/vendor/magento/module-page-builder/Model/Dom/NodeList.php on line 19
> 
> Fatal error: Declaration of Magento\PageBuilder\Model\Dom\NodeList::item($index): ?Magento\PageBuilder\Model\Dom\Adapter\ElementInterface must be compatible with Magento\PageBuilder\Model\Dom\Adapter\NodeListInterface::item(int $index): ?Magento\PageBuilder\Model\Dom\Adapter\ElementInterface in /var/www/html/vendor/magento/module-page-builder/Model/Dom/NodeList.php on line 19

### Fixed Issues (if relevant)
*None known*

### Manual testing scenarios
1. `php bin/magento setup:di:compile`

### Questions or comments
*None*

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)