### PR TITLE
[1.3-develop] Fix iframe event handling with more than one page builder instance on the page

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/web/js/master-format/render.js
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/js/master-format/render.js
@@ -88,14 +88,14 @@ define(["jquery", "Magento_PageBuilder/js/config", "Magento_PageBuilder/js/maste
       this.channel = new MessageChannel();
       var frame = this.getRenderFrame();
       window.addEventListener("message", function (event) {
-        if (!_this2.ready && event.data === "PB_RENDER_READY") {
+        if (!_this2.ready && event.data.name === "PB_RENDER_READY" && _this2.stageId === event.data.stageId) {
           frame.contentWindow.postMessage("PB_RENDER_PORT", "*", [_this2.channel.port2]);
           _this2.ready = true;
 
           _this2.readyDeferred.resolve();
         }
       });
-      frame.src = _config.getConfig("render_url");
+      frame.src = _config.getConfig("render_url") + "?stageId=" + this.stageId;
     }
     /**
      * Use the text! RequireJS plugin to load a template and send it back to the child render iframe

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/js/master-format/render/frame.js
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/js/master-format/render/frame.js
@@ -32,6 +32,8 @@ define(["jquery", "knockout", "Magento_Ui/js/lib/knockout/template/engine", "mag
 
 
   function listen(config) {
+    var stageId = window.location.href.split("?")[1].split("=")[1];
+
     _config.setConfig(config);
 
     _config.setMode("Master");
@@ -66,7 +68,10 @@ define(["jquery", "knockout", "Magento_Ui/js/lib/knockout/template/engine", "mag
       }
     }, false); // Inform the parent iframe that we're ready to receive the port
 
-    window.parent.postMessage("PB_RENDER_READY", "*");
+    window.parent.postMessage({
+      name: "PB_RENDER_READY",
+      stageId: stageId
+    }, "*");
   }
   /**
    * Use our MessageChannel to load a template from the parent window, this is required as the iframe isn't allowed to

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/ts/js/master-format/render.ts
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/ts/js/master-format/render.ts
@@ -80,13 +80,13 @@ export default class MasterFormatRenderer {
         this.channel = new MessageChannel();
         const frame = this.getRenderFrame();
         window.addEventListener("message", (event) => {
-            if (!this.ready && event.data === "PB_RENDER_READY") {
+            if (!this.ready && event.data.name === "PB_RENDER_READY" && this.stageId === event.data.stageId) {
                 frame.contentWindow.postMessage("PB_RENDER_PORT", "*", [this.channel.port2]);
                 this.ready = true;
                 this.readyDeferred.resolve();
             }
         });
-        frame.src = Config.getConfig("render_url");
+        frame.src = Config.getConfig("render_url") + "?stageId=" + this.stageId;
     }
 
     /**

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/ts/js/master-format/render/frame.ts
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/ts/js/master-format/render/frame.ts
@@ -41,6 +41,8 @@ const debounceRender = _.debounce((message: {stageId: string, tree: TreeItem}, r
  * Listen for requests from the parent window for a render
  */
 export default function listen(config: ConfigInterface) {
+    const stageId = window.location.href.split("?")[1].split("=")[1];
+
     Config.setConfig(config);
     Config.setMode("Master");
 
@@ -74,7 +76,7 @@ export default function listen(config: ConfigInterface) {
     );
 
     // Inform the parent iframe that we're ready to receive the port
-    window.parent.postMessage("PB_RENDER_READY", "*");
+    window.parent.postMessage({name: "PB_RENDER_READY", stageId}, "*");
 }
 
 /**


### PR DESCRIPTION
### Description (*)
Saving admin UI forms that include page builder activated fields. The specific error that appears in the console is [ERROR] Page Builder was rendering for 5 seconds without releasing locks. which results in the form save being prevented and the bodyProcess('start') loader displayed


### Manual testing scenarios (*)
1. Duplicate WYSIWYG field on cms_block_form.xml
2. Open CMS Block page in admin
3. Save Block


### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
