### PR TITLE
#510: User edits CMS page content in full-screen mode only  #1 - Merg…

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/ui_component/cms_page_form.xml
+++ b/app/code/Magento/PageBuilder/view/adminhtml/ui_component/cms_page_form.xml
@@ -12,7 +12,6 @@
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">page</item>
                     <item name="wysiwygConfigData" xsi:type="array">
-                        <item name="is_pagebuilder_enabled" xsi:type="boolean">true</item>
                         <item name="pagebuilder_content_snapshot" xsi:type="boolean">true</item>
                         <item name="pagebuilder_button" xsi:type="boolean">true</item>
                     </item>


### PR DESCRIPTION
…ed develop and add a button to the CMS Edit page

### Description (*)
- Add a button to the CMS Edit page (Subtask 1)
- Remove navigation items (Subtask 3)
  - remove content-types 
  - template buttons
  - do not trigger option panels on each content-type

### Story
https://github.com/magento/magento2-page-builder/issues/510 - User edits CMS page content in full-screen mode only

### Screenshot
![image](https://user-images.githubusercontent.com/58731874/87420166-0fae2b80-c5d5-11ea-8437-7176ec7fb762.png)


### Acceptance Criteria 
#### Subtask 1
- [x] User scrolls to the attributes that controlled by Page Builder and sees stage with the content.
- [x] User sees option to edit/add content
- [x] User sees navigation panel and other controls that allow to edit content
- [x] User makes the changes to the content, exits full screen mode and sees Page Builder stage in context of Product Admin Page without any editing controls
- [x] User sees content adjusts to the new viewport size and includes all the changes they've done
- [x] User saves the page and see changes on the storefront
#### Subtask 2
- [x] User doesn't see Page Builder navigational elements

### Related Pull Requests
https://github.com/magento/magento2-page-builder/pull/562 - Main Story

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
