### PR TITLE
magento/magento2-page-builder#510: User edits CMS page content in ful…

### DIFF
--- a/app/code/Magento/PageBuilder/Component/Form/Element/Wysiwyg.php
+++ b/app/code/Magento/PageBuilder/Component/Form/Element/Wysiwyg.php
@@ -66,7 +66,7 @@ class Wysiwyg extends \Magento\Ui\Component\Form\Element\Wysiwyg
             $data['config']['component'] = 'Magento_PageBuilder/js/form/element/wysiwyg';
 
             // Override the templates to include our KnockoutJS code
-            $data['config']['template'] = 'Magento_PageBuilder/form/element/wysiwyg';
+            $data['config']['template'] = 'ui/form/field';
             $data['config']['elementTmpl'] = 'Magento_PageBuilder/form/element/wysiwyg';
             $wysiwygConfigData = $stageConfig->getConfig();
             $data['config']['wysiwygConfigData'] = isset($config['wysiwygConfigData']) ?

--- a/app/code/Magento/PageBuilder/view/adminhtml/ui_component/cms_page_form.xml
+++ b/app/code/Magento/PageBuilder/view/adminhtml/ui_component/cms_page_form.xml
@@ -17,6 +17,11 @@
                     </item>
                 </item>
             </argument>
+            <settings>
+                <additionalClasses>
+                    <class name="admin__field-wide admin__field-page-builder">true</class>
+                </additionalClasses>
+            </settings>
         </field>
     </fieldset>
 </form>


### PR DESCRIPTION
### Description
Change form "Edit with Page Builder" button position.

### Screenshot
![cms-page-button-position](https://user-images.githubusercontent.com/22525219/87938759-55686980-ca97-11ea-818d-51d34e94456f.png)

### Story
https://github.com/magento/magento2-page-builder/issues/510 - User edits CMS page content in full-screen mode only

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
