### PR TITLE
#512:  User edits Blocks content in full-screen mode only #1 - added …

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/ui_component/cms_block_form.xml
+++ b/app/code/Magento/PageBuilder/view/adminhtml/ui_component/cms_block_form.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <fieldset name="general">
+        <field name="content" formElement="wysiwyg">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="wysiwygConfigData" xsi:type="array">
+                        <item name="pagebuilder_content_snapshot" xsi:type="boolean">true</item>
+                        <item name="pagebuilder_button" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
+            <settings>
+                <additionalClasses>
+                    <class name="admin__field-wide admin__field-page-builder">true</class>
+                </additionalClasses>
+            </settings>
+        </field>
+    </fieldset>
+</form>

--- a/app/code/Magento/PageBuilder/view/adminhtml/ui_component/cmsstaging_block_update_form.xml
+++ b/app/code/Magento/PageBuilder/view/adminhtml/ui_component/cmsstaging_block_update_form.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <fieldset name="general">
+        <field name="content" formElement="wysiwyg">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="wysiwygConfigData" xsi:type="array">
+                        <item name="pagebuilder_content_snapshot" xsi:type="boolean">true</item>
+                        <item name="pagebuilder_button" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
+            <settings>
+                <additionalClasses>
+                    <class name="admin__field-wide admin__field-page-builder">true</class>
+                </additionalClasses>
+            </settings>
+        </field>
+    </fieldset>
+</form>


### PR DESCRIPTION
…he snapshot mode for blocks and staging blocks

### Description 
As a Marketer I want to edit content in full screen mode only so that I have optimised experience with more space available and stage preview be closer to storefront view

### Acceptance Criteria
- Add a button to the Block Edit page
  - [x] User scrolls to the attributes that controlled by Page Builder and sees stage with the content.
  - [x] User sees option to edit/add content
  - [x] User sees navigation panel and other controls that allow to edit content
  - [x] User makes the changes to the content, exits full screen mode and sees Page Builder stage in context of Product Admin 
  - [x] Page without any editing controls
  - [x] User sees content adjusts to the new viewport size and includes all the changes they've done
  - [x] User saves the page and see changes on the storefront
- Remove navigation items (remove content-types, template buttons, do not trigger option panels on each content-type)
  - [x] user doesn't see Page Builder navigational elements
- Make sure the Staging update form aligned with the main form
  - [x] If user creates a staging update for the page, they have the same experience (all the AC above applicable) as when they update the content directly

### Story
https://github.com/magento/magento2-page-builder/issues/512 - User edits blocks content in full-screen mode only

### Screenshot
Blocks:
![image](https://user-images.githubusercontent.com/58731874/88287646-df603e80-ccf2-11ea-93bd-a1c8c2257647.png)
![image](https://user-images.githubusercontent.com/58731874/88288862-a4f7a100-ccf4-11ea-9fd4-fb7f01319d5a.png)
Stage:
![image](https://user-images.githubusercontent.com/58731874/88287834-2c441500-ccf3-11ea-9493-f7b6cc027be1.png)

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
