### PR TITLE
fix SlideItemDeleteImageTest mftf test failure

### DIFF
--- a/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderSlideItemCommonTest/SlideItemDeleteImageTest.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderSlideItemCommonTest/SlideItemDeleteImageTest.xml
@@ -73,7 +73,12 @@
         <!-- Delete image A -->
         <comment stepKey="deleteImageA" userInput="Delete image A"/>
         <waitForElementVisible selector="{{MediaGallerySection.lastImageOrImageCopy(PageBuilderBackgroundImage_GIF.fileName, PageBuilderBackgroundImage_GIF.extension)}}" stepKey="waitForLastImage"/>
-        <click selector="{{MediaGallerySection.lastImageOrImageCopy(PageBuilderBackgroundImage_GIF.fileName, PageBuilderBackgroundImage_GIF.extension)}}" stepKey="selectImage"/>
+        <conditionalClick
+            selector="{{MediaGallerySection.lastImageOrImageCopy(PageBuilderBackgroundImage_GIF.fileName, PageBuilderBackgroundImage_GIF.extension)}}"
+            dependentSelector="{{MediaGallerySection.lastImageOrImageCopySelected(PageBuilderBackgroundImage_GIF.fileName, PageBuilderBackgroundImage_GIF.extension)}}"
+            visible="true"
+            stepKey="selectImage"
+        />
         <actionGroup ref="DeleteImageFromStorageActionGroup" stepKey="DeleteImageFromStorage1">
             <argument name="Image" value="PageBuilderBackgroundImage_GIF"/>
         </actionGroup>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fix failure of MFTF test Magento/PageBuilder/Test/Mftf/Test/AdminPageBuilderSlideItemCommonTest/SlideItemDeleteImageTest.xml
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added additional click for unselecting image in gallery

### Bug
* [29310](https://github.com/magento/magento2/issues/29310) Requested  default folder is not selected on opening media gallery (current_tree_path parameter) 

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
