### PR TITLE
Added wiki links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,25 @@ Welcome to the Magento 2 Page Builder project!
 
 Page Builder introduces an intuitive, drag-and-drop interface for creating digital content, powered by content types like images, videos, banners, etc. with instant preview capabilities that enable non-technical users to take control of their content. It allows to create new pages, enrich products and categories, and launch content updates quickly and easily without the help of a front-end web developer.
 
+## Wiki
+
+Public access to the Page Builder wiki is found here:
+
+https://github.com/magento/magento2-page-builder-docs/wiki.
+
+The wiki provides more information on the Page Builder project, such as:
+
+- [Links to User Guide tutorials](https://github.com/magento/magento2-page-builder-docs/wiki#page-builder-tutorials)
+- [Page Builder roadmaps](https://github.com/magento/magento2-page-builder-docs/wiki#roadmap)
+- [MFTF best practices](https://github.com/magento/magento2-page-builder-docs/wiki/%5BRough-Draft%5D-MFTF-Best-Practices)
+- [Partners Acceleration Program](https://github.com/magento/magento2-page-builder-docs/wiki/Partners-Acceleration-Program-Team)
+
 ## Documentation
-Complete documentation located on the [Magento DevDocs](https://devdocs.magento.com/page-builder/docs/):
-  - Project [roadmap](https://github.com/magento/magento2-page-builder/wiki#roadmap) contains information about project phases 
-  - How to start local development described in the [installation guide](https://devdocs.magento.com/page-builder/docs/getting-started/install-pagebuilder.html)
+Complete documentation located on the [Magento DevDocs](https://devdocs.magento.com/page-builder/docs/), including what you need to know to start local development as described in the [installation guide](https://devdocs.magento.com/page-builder/docs/getting-started/install-pagebuilder.html).
 
 ## Community Engineering Slack
 
-To connect with Magento team and the Community, join us on the [Magento Community Engineering Slack](https://magentocommeng.slack.com). 
+To connect with Magento team and the Community, join us on the [Magento Community Engineering Slack](https://magentocommeng.slack.com).
 If you are interested in joining Slack, or a specific channel, use our [self signup](https://opensource.magento.com/slack) link.
 
 Magento 2 Page Builder project slack channel: [#pagebuilder](https://magentocommeng.slack.com/archives/CHB455HPF)


### PR DESCRIPTION
### Description (*)

This PR updates the README by adding links to the public wiki for the Page Builder project. 

### Reason

Last week, we switched our GitHub licensing plan on the “magento” org. The new plan does not allow wikis on private repos. So we moved the wiki to the wiki of the public Page Builder docs repo (https://github.com/magento/magento2-page-builder-docs/wiki) and created links to that repo from the README as a solution.

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
