### PR TITLE
Fixing strict sprintf Phrases in php8

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Stage/Renderer/CmsStaticBlock.php
+++ b/app/code/Magento/PageBuilder/Model/Stage/Renderer/CmsStaticBlock.php
@@ -92,7 +92,7 @@ class CmsStaticBlock implements \Magento\PageBuilder\Model\Stage\RendererInterfa
             ->load();
 
         if ($blocks->count() === 0) {
-            $result['error'] = sprintf(__('Block with ID: %s doesn\'t exist'), $params['block_id']);
+            $result['error'] = sprintf(__('Block with ID: %s doesn\'t exist')->render(), $params['block_id']);
 
             return $result;
         }

--- a/app/code/Magento/PageBuilder/Ui/Component/UrlInput/Page/Options.php
+++ b/app/code/Magento/PageBuilder/Ui/Component/UrlInput/Page/Options.php
@@ -43,7 +43,7 @@ class Options implements \Magento\Framework\Data\OptionSourceInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @return array
      */
@@ -59,7 +59,7 @@ class Options implements \Magento\Framework\Data\OptionSourceInterface
                 $this->options[$pageId] = [
                     'value' => $pageId,
                     'label' => $item->getTitle(),
-                    'identifier' => sprintf(__('ID: %s'), $pageId)
+                    'identifier' => sprintf(__('ID: %s')->render(), $pageId)
                 ];
             }
         }

--- a/dev/tests/integration/testsuite/Magento/PageBuilder/Ui/Component/UrlInput/Page/OptionsTest.php
+++ b/dev/tests/integration/testsuite/Magento/PageBuilder/Ui/Component/UrlInput/Page/OptionsTest.php
@@ -34,7 +34,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
             $options[$pageId] = [
                 'value' => $pageId,
                 'label' => $item->getTitle(),
-                'identifier' => sprintf(__('ID: %s'), $pageId)
+                'identifier' => sprintf(__('ID: %s')->render(), $pageId)
             ];
         }
         return $options;


### PR DESCRIPTION
### Description (*)
This PR aims to fix rendering the Phrases in sprintf, which gets only string param.

### Story
<!--- 
* [<issue_number>](https://jira.corp.magento.com/browse/<issue_number>) <issue_title>
-->

### Bug
<!--- 
* [<issue_number>](https://jira.corp.magento.com/browse/<issue_number>) <issue_title>
-->

### Task
<!--- 
* [<issue_number>](https://jira.corp.magento.com/browse/<issue_number>) <issue_title>
-->

### Fixed Issues (if relevant)
1. magento/magento2/issues/34085

### Builds
<!--- 
[All-User-Requested-Tests](https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/<build_number>)
-->

### Related Pull Requests
<!--- 
https://github.com/magento/magento2ce/pull/<related_pr>
-->
<!-- related pull request placeholder -->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
