### PR TITLE
Stop forcing category pages to 2column-left layout

### DIFF
--- a/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
+++ b/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="category.view.container">
             <referenceBlock name="category.description" template="Magento_PageBuilder::catalog/category/view/description.phtml"/>


### PR DESCRIPTION
### Description (*)
My site uses 1column layout for category pages. This worked fine until PageBuilder came along. This is the fix.


### Builds
<!--- 
[All-User-Requested-Tests](https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/<build_number>)
-->

### Related Pull Requests
<!--- 
https://github.com/magento/magento2ce/pull/<related_pr>
-->
<!-- related pull request placeholder -->

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
