### PR TITLE
Ensure Validator Value Exists Before Use

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/web/js/form/element/validator-rules-mixin.js
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/js/form/element/validator-rules-mixin.js
@@ -231,6 +231,10 @@ define([
         validator.addRule(
             'required-entry',
             function (value) {
+                if (!value) {
+                    return true;
+                }
+
                 var allFilled;
 
                 // Validation only for margins and paddings


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Check for non-null values during margin and padding validation. Seems to be affecting Firefox 94.0.2 during cursory testing.

#### Dev Tools Error
```javascript
Uncaught TypeError: value is null
    <anonymous> https://www.{{project-name}}.test/static/version1637759357/adminhtml/Magento/backend/en_GB/Magento_PageBuilder/js/form/element/validator-rules-mixin.js:237
    validate https://www.{{project-name}}.test/static/version1637759357/adminhtml/Magento/backend/en_GB/Magento_Ui/js/lib/validation/validator.js:44
    validator https://www.{{project-name}}.test/static/version1637759357/adminhtml/Magento/backend/en_GB/Magento_Ui/js/lib/validation/validator.js:84
    all Underscore
    validator https://www.{{project-name}}.test/static/version1637759357/adminhtml/Magento/backend/en_GB/Magento_Ui/js/lib/validation/validator.js:82
    validate https://www.{{project-name}}.test/static/version1637759357/adminhtml/Magento/backend/en_GB/Magento_Ui/js/form/element/abstract.js:406
    setNested https://www.{{project-name}}.test/static/version1637759357/adminhtml/Magento/backend/en_GB/mage/utils/objects.js:44
validator-rules-mixin.js:237:51
```

![Screenshot 2021-11-24 at 14 24 54](https://user-images.githubusercontent.com/40261741/143258384-f64e5f5c-cdc4-4114-b42a-8aa09ddc06c2.png)

### Story
N/A

### Bug
N/A

### Task
N/A

### Fixed Issues (if relevant)
N/A

### Builds
<!--- 
[All-User-Requested-Tests](https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/<build_number>)
-->

### Related Pull Requests
N/A

### Manual testing scenarios (*)
With `null` margin and/or padding values in product Page Builder content:

1. Log into the admin using Firefox 94.0.2
2. Navigate to `Catalog -> Inventory -> Products`
3. Select the `Edit` action from the `Action` column in the products grid
4. Observe the page for the infinite loading spinner and examine the developer console for the aforementioned error

### Questions or comments
N/A

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
