### PR TITLE
Changed restrictions for php to "~7.4.0||~8.1.0" into `composer.json` files

### DIFF
--- a/app/code/Magento/AwsS3PageBuilder/composer.json
+++ b/app/code/Magento/AwsS3PageBuilder/composer.json
@@ -3,7 +3,7 @@
     "description": "Aws S3 Page Builder module",
     "require": {
         "magento/framework": "*",
-        "php": "~7.4.0||~8.0.0||~8.1.0"
+        "php": "~7.4.0||~8.1.0"
     },
     "suggest": {
         "magento/module-page-builder": "*",

--- a/app/code/Magento/CatalogPageBuilderAnalytics/composer.json
+++ b/app/code/Magento/CatalogPageBuilderAnalytics/composer.json
@@ -8,7 +8,7 @@
         "magento/module-page-builder-analytics": "*",
         "magento/module-catalog": "*",
         "magento/framework": "*",
-        "php": "~7.4.0||~8.0.0||~8.1.0"
+        "php": "~7.4.0||~8.1.0"
     },
     "type": "magento2-module",
     "license": [

--- a/app/code/Magento/CmsPageBuilderAnalytics/composer.json
+++ b/app/code/Magento/CmsPageBuilderAnalytics/composer.json
@@ -8,7 +8,7 @@
         "magento/module-page-builder-analytics": "*",
         "magento/module-cms": "*",
         "magento/framework": "*",
-        "php": "~7.4.0||~8.0.0||~8.1.0"
+        "php": "~7.4.0||~8.1.0"
     },
     "type": "magento2-module",
     "license": [

--- a/app/code/Magento/PageBuilder/composer.json
+++ b/app/code/Magento/PageBuilder/composer.json
@@ -21,7 +21,7 @@
         "magento/module-wishlist": "*",
         "magento/module-require-js": "*",
         "magento/module-media-storage": "*",
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "phpgt/dom": "2.2.3"
     },
     "suggest": {

--- a/app/code/Magento/PageBuilderAdminAnalytics/composer.json
+++ b/app/code/Magento/PageBuilderAdminAnalytics/composer.json
@@ -6,7 +6,7 @@
     },
     "require": {
         "magento/framework": "*",
-        "php": "~7.4.0||~8.0.0||~8.1.0"
+        "php": "~7.4.0||~8.1.0"
     },
     "suggest": {
         "magento/module-admin-analytics": "*",

--- a/app/code/Magento/PageBuilderAnalytics/composer.json
+++ b/app/code/Magento/PageBuilderAnalytics/composer.json
@@ -5,7 +5,7 @@
         "magento/module-analytics": "*",
         "magento/module-page-builder": "*",
         "magento/framework": "*",
-        "php": "~7.4.0||~8.0.0||~8.1.0"
+        "php": "~7.4.0||~8.1.0"
     },
     "type": "magento2-module",
     "license": [


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request (PR) provides fixes for `composer.json` files

1. remove restriction `"~8.0.0"` for `"php"` requirements

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/partners-magento2b2b#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#34852

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
