### PR TITLE
Fixes less/css compilation when using less.js v4

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/web/css/source/content-type/products/_default.less
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/css/source/content-type/products/_default.less
@@ -234,7 +234,7 @@
     }
 
     .product-reviews-summary {
-        margin-bottom: @indent__s + @indent__xs;
+        margin-bottom: (@indent__s + @indent__xs);
 
         .reviews-actions {
             display: inline-block;


### PR DESCRIPTION
### Description (*)
This complements https://github.com/magento/magento2/pull/38335

In your internal tickets AC-8098 & AC-9713 less.js got upgraded from v3 to v4
However, that switch is not fully backwards compatible, the math stuff now needs to be encapsulated in parentheses for less.js to do the calculation and not output it as-is to the generated css.

This module only has one mistake as far as I could find, this is the output of compiling the less code like it is right now with v4 compared to v3 and this results in invalid css:
```diff
--- pub/static/adminhtml/Magento/backend/en_US/css/styles.css 2024-01-08 17:44:24
+++ pub/static/adminhtml/Magento/backend/en_US/css/styles.css  2024-01-08 17:44:34
@@ -13248,7 +13248,7 @@
 }
 [data-content-type='products'] .product-reviews-summary,
 .pagebuilder-products .product-reviews-summary {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem + 0.5rem;
 }
 [data-content-type='products'] .product-reviews-summary .reviews-actions,
 .pagebuilder-products .product-reviews-summary .reviews-actions {
```

This PR fixes it and will output `margin-bottom: 1.5rem;` again.

### Manual testing scenarios (*)
See testing scenario in https://github.com/magento/magento2/pull/38335

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
