### PR TITLE
Fix #866: Add element existence check to prevent Page Builder editor crashes

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/web/js/stage-builder.js
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/js/stage-builder.js
@@ -49,6 +49,11 @@ define(["mage/translate", "Magento_PageBuilder/js/events", "Magento_Ui/js/modal/
       _.each(styles, function (stylesArray, selector) {
         var element = document.querySelector(selector);
 
+        if (!element) {
+          console.error('Element not found for selector: %o. Unable to set attribute: "%s".', selector, "data-" + name + "-style");
+          return;
+        }
+
         _.each(stylesArray, function (style) {
           element.setAttribute("data-" + name + "-style", element.getAttribute("data-" + name + "-style") ? element.getAttribute("data-" + name + "-style") + style.cssText : style.cssText);
         });

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/ts/js/stage-builder.ts
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/ts/js/stage-builder.ts
@@ -58,7 +58,12 @@ function convertToInlineStyles(document: Document): void {
 
     _.each(viewportStyles, (styles, name: string) => {
         _.each(styles, (stylesArray: CSSStyleDeclaration[], selector: string) => {
-            const element: HTMLElement = document.querySelector(selector);
+            const element = document.querySelector<HTMLElement>(selector);
+
+            if (!element) {
+                console.error('Element not found for selector: %o. Unable to set attribute: "%s".', selector, `data-${name}-style`);
+                return;
+            }
 
             _.each(stylesArray, (style: CSSStyleDeclaration) => {
                 element.setAttribute(


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

We encountered a scenario where missing HTML elements in Page Builder led to runtime errors due to direct calls to `setAttribute`.

To address this, we added an existence check before setting attributes. This change prevents the editor from breaking and improves stability by handling cases where elements are missing.

Ideally, the core should include such checks to enhance overall resilience and user experience.

### Story
N/A

### Bug
N/A

### Task
N/A

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-page-builder#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2-page-builder#866: Graceful Handling of Null element in Page Builder to Prevent Editor Failure

### Builds
<!--- 
[All-User-Requested-Tests](https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/<build_number>)
-->
N/A

### Related Pull Requests
<!--- 
https://github.com/magento/magento2ce/pull/<related_pr>
-->
<!-- related pull request placeholder -->
N/A

### Manual Testing Scenarios

Please test the following scenarios to verify the changes:

1. **Remove `data-pb-style` Attribute**:
   - Remove the `data-pb-style` attribute from an element with applied styles.
   - Ensure the Page Builder continues to work without issues.

2. **Modify `data-pb-style` Hash**:
   - Change the `data-pb-style` attribute's value to a non-relevant hash.
   - Confirm that the Page Builder handles this gracefully and remains functional.

3. **Remove HTML Element**:
   - Delete the HTML element to which styles are applied.
   - Check that the Page Builder does not crash and continues to operate normally.

**Note**: This issue was observed when using the DeepL API, but similar problems might occur in other scenarios. The preview editor should remain stable.

### Questions or comments
N/A

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
