### PR TITLE
tinyMCE migration 5to7

### DIFF
--- a/app/code/Magento/PageBuilder/Model/Wysiwyg/DefaultConfigProvider.php
+++ b/app/code/Magento/PageBuilder/Model/Wysiwyg/DefaultConfigProvider.php
@@ -42,7 +42,7 @@ class DefaultConfigProvider implements \Magento\Framework\Data\Wysiwyg\ConfigPro
         $config->addData(
             [
                 'tinymce' => [
-                    'toolbar' => 'undo redo | styles | fontsizeselect | lineheight | forecolor backcolor ' .
+                    'toolbar' => 'undo redo | styles | fontsize | lineheight | forecolor backcolor ' .
                         '| bold italic underline | alignleft aligncenter alignright | numlist bullist ' .
                         '| link image table charmap',
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In TinyMCE 5, the toolbar font size option is referred to as `fontsizeselect`. However, in TinyMCE 7, this option has been renamed to `fontsize`. This causes compatibility issues when migrating from TinyMCE 5 to TinyMCE 7 as the old toolbar configuration (fontsizeselect) no longer works in the new version.

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
