### PR TITLE
add condition to product options

### DIFF
--- a/app/code/Magento/PageBuilder/view/frontend/templates/catalog/product/widget/content/carousel.phtml
+++ b/app/code/Magento/PageBuilder/view/frontend/templates/catalog/product/widget/content/carousel.phtml
@@ -61,11 +61,13 @@ use Magento\Framework\App\Action\Action;
                                         <?php if ($_item->isSaleable()): ?>
                                             <?php $postParams = $block->getAddToCartPostParams($_item); ?>
                                             <form data-role="tocart-form" data-product-sku="<?= $escaper->escapeHtml($_item->getSku()) ?>" action="<?= $escaper->escapeUrl($postParams['action']) ?>" method="post">
+                                            <?php if (isset($postParams['data']['options'])): ?>
                                                 <?php foreach ($postParams['data']['options'] as $optionItem): ?>
                                                     <input type="hidden"
                                                            name="<?= $escaper->escapeHtml($optionItem['name']) ?>"
                                                            value="<?= $escaper->escapeHtml($optionItem['value']) ?>">
                                                 <?php endforeach; ?>
+                                            <?php endif ?>
                                                 <input type="hidden" name="product" value="<?= $escaper->escapeHtmlAttr($postParams['data']['product']) ?>">
                                                 <input type="hidden" name="<?= /* @noEscape */ Action::PARAM_NAME_URL_ENCODED ?>" value="<?= /* @noEscape */ $postParams['data'][Action::PARAM_NAME_URL_ENCODED] ?>">
                                                 <?= $block->getBlockHtml('formkey') ?>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->


### Preconditions (*)

1. Magento 2.4.7-p4
2. page builder v-1.7.5-beta1 
3. page builder v-1.7.5-beta2

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When adding a Product Slider through Page Builder and selecting the Product Carousel appearance, an error occurs:
“Error filtering template: Warning: Undefined array key "options" in /var/www/public_html/vendor/magento/module-page-builder/view/frontend/templates/catalog/product/widget/content/carousel.phtml on line 64”


### Related Issue(*)
<!--- 
* [<issue_number>](https://jira.corp.magento.com/browse/<issue_number>) <issue_title>
-->
Fixes #891 

### Manual testing scenarious(*)
<!--- 
* [<issue_number>](https://jira.corp.magento.com/browse/<issue_number>) <issue_title>
-->
1. Log in to the Magento Admin Panel.
2. Navigate to Content → Blocks and click on Add New Block.
3. Click Edit with Page Builder and add a Row.
4. Expand the Add Content menu and drag the Product widget onto the row.
5. Click Edit, select a Category, and choose Appearance: Product Carousel.
6. Save the Edit Products and observe the error.

### Expected result (*)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-page-builder#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
The Product Slider should appear correctly after saving Edit Products.

### Actual result (*)
<!--- 
[All-User-Requested-Tests](https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/<build_number>)
-->
After saving Edit Products an error message is displayed instead of the Product Slider.
### Additional Information(*)
<!--- 
https://github.com/magento/magento2ce/pull/<related_pr>
-->
As I checked in file magento/module-page-builder /view/frontend/templates/catalog/product/widget/content/carousel.phtml The issue occurs when the product slider does not have a bundle product. At that time, the options are not defined, causing an error.
<!-- related pull request placeholder -->

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
