### PR TITLE
Fixed Banner element overlay issue on mobile when min-height is customized

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/banner/converter/style/overlay-background-color.js
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/banner/converter/style/overlay-background-color.js
@@ -2,7 +2,7 @@
 /* jscs:disable */
 define(["Magento_PageBuilder/js/utils/object"], function (_object) {
   /**
-   * Copyright 2025 Adobe
+   * Copyright 2018 Adobe
    * All Rights Reserved.
    */
   var OverlayBackgroundColor = /*#__PURE__*/function () {

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/banner/converter/style/overlay-background-color.js
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/banner/converter/style/overlay-background-color.js
@@ -37,7 +37,7 @@ define(["Magento_PageBuilder/js/utils/object"], function (_object) {
         return value;
       }
 
-      return "transparent";
+      return "";
     };
 
     return OverlayBackgroundColor;

--- a/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/banner/converter/style/overlay-background-color.js
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/js/content-type/banner/converter/style/overlay-background-color.js
@@ -2,8 +2,8 @@
 /* jscs:disable */
 define(["Magento_PageBuilder/js/utils/object"], function (_object) {
   /**
-   * Copyright © Magento, Inc. All rights reserved.
-   * See COPYING.txt for license details.
+   * Copyright 2025 Adobe
+   * All Rights Reserved.
    */
   var OverlayBackgroundColor = /*#__PURE__*/function () {
     "use strict";


### PR DESCRIPTION
### Preconditions (*)
Tested in this versions:
Magento 2.4.8
### Description (*)
When we set a custom minimum height for the banner, the content overlay doesn’t show up on the mobile frontend.
### Steps to reproduce (*)
1. Go to Content > Pages Or Blocks.
2. Edit a page or block using Page Builder.
3. Drag and drop a Banner element.
4. Add text, button and overlay color in the content area.
5. In mobile view, change the banner set a minimum height that's different from the desktop view. The issue happens only when mobile and desktop have different heights. (e.g Desktop minimum height 300px and Mobile minimum height 301px) (See Screenshot 1).
6. Save and view the page on mobile device (or emulate with browser tools).
### Screenshot-1
![Image](https://github.com/user-attachments/assets/376b7ab3-d5bd-4983-82e3-7fc2631f0490)
### Expected result (*)
When setting a custom minimum height value for the Banner element in Page Builder’s mobile view, the content overlay (text/button layer) should be visible (See Screenshot 2).
### Screenshot-2
![Image](https://github.com/user-attachments/assets/a6d90447-9d7f-43b1-87df-80467ba99432)
### Actual result (*)
When setting a custom minimum height value for the Banner element in Page Builder’s mobile view, the content overlay (text/button layer) is not clearly visible (See Screenshot 3).
### Screenshot-3
![Image](https://github.com/user-attachments/assets/076e9623-2e33-4249-9959-1af4fb79412d)
### Additional information (*)
In the banner element on mobile viewports, when we change the custom minimum height value, the banner overlay background color becomes transparent (See Screenshot 4).
### Screenshot-4
![Image](https://github.com/user-attachments/assets/cc8eb90e-fcdb-4a1c-b446-b16c47c2831d)

### Resolved issues:
1. [x] resolves magento/magento2-page-builder#901: Fixed Banner element overlay issue on mobile when min-height is customized