### PR TITLE
Fix page layout xml of pagebuilder overriding the layout set by theme

### DIFF
--- a/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminCatalogCategoryPageBuilderTest/PageBuilderCatalogCategoryVerifyLayoutOverrideIsRespectedTest.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminCatalogCategoryPageBuilderTest/PageBuilderCatalogCategoryVerifyLayoutOverrideIsRespectedTest.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright 2019 Adobe
+  * All Rights Reserved.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="PageBuilderCatalogCategoryVerifyLayoutOverrideIsRespectedTest">
+        <annotations>
+            <features value="PageBuilder"/>
+            <stories value="Catalog Category"/>
+            <title value="Verify layout override is respected on category page when PageBuilder is active"/>
+            <description value="When PageBuilder is active on a category page, the page layout should not be hardcoded. A layout set on the category design settings must be respected on the storefront, allowing themes to control the layout."/>
+            <severity value="AVERAGE"/>
+            <group value="pagebuilder"/>
+            <group value="pagebuilder-layout"/>
+            <group value="pagebuilder-catalog-category"/>
+        </annotations>
+        <before>
+            <createData entity="_defaultCategory" stepKey="createCategory"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+        </after>
+
+        <!-- Navigate to category and expand content section -->
+        <actionGroup ref="NavigateToCreatedCategoryActionGroup" stepKey="navigateToCreatedCategory">
+            <argument name="Category" value="$$createCategory$$"/>
+        </actionGroup>
+        <actionGroup ref="expandAdminCategorySection" stepKey="expandContentSection"/>
+
+        <!-- Enable PageBuilder on category description and add a row to confirm PageBuilder is active -->
+        <actionGroup ref="openPageBuilderForAttribute" stepKey="openPageBuilderForAttribute"/>
+        <actionGroup ref="dragContentTypeToStage" stepKey="dragRowToRootContainer">
+            <argument name="contentType" value="PageBuilderRowContentType"/>
+            <argument name="containerTargetType" value="PageBuilderRootContainerContentType"/>
+        </actionGroup>
+        <actionGroup ref="exitPageBuilderFullScreen" stepKey="exitPageBuilderFullScreen"/>
+
+        <!-- Override the layout to 1 column via category design settings -->
+        <actionGroup ref="SetLayoutActionGroup" stepKey="setOneColumnLayout">
+            <argument name="designSection" value="CategoryDesignSection"/>
+            <argument name="layoutOption" value="1 column"/>
+        </actionGroup>
+
+        <!-- Save the category -->
+        <actionGroup ref="saveCatalogCategory" stepKey="saveCatalogCategory"/>
+
+        <!-- Navigate to storefront and verify the layout override is respected -->
+        <actionGroup ref="StorefrontGoToCategoryPageActionGroup" stepKey="openStorefrontCategoryPage">
+            <argument name="categoryName" value="$$createCategory.name$$"/>
+        </actionGroup>
+
+        <!-- Verify the 1 column layout class is applied on the body -->
+        <seeElement selector="body.page-layout-1column" stepKey="seeOneColumnLayoutClass"/>
+
+        <!-- Verify the previously hardcoded 2columns-left layout is not applied -->
+        <dontSeeElement selector="body.page-layout-2columns-left" stepKey="dontSeeTwoColumnsLeftLayoutClass"/>
+    </test>
+</tests>

--- a/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminCatalogCategoryPageBuilderTest/PageBuilderCatalogCategoryVerifyLayoutOverrideIsRespectedTest.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminCatalogCategoryPageBuilderTest/PageBuilderCatalogCategoryVerifyLayoutOverrideIsRespectedTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  /**
-  * Copyright 2019 Adobe
+  * Copyright 2026 Adobe
   * All Rights Reserved.
   */
 -->

--- a/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminCatalogCategoryPageBuilderTest/PageBuilderCatalogCategoryVerifyLayoutOverrideIsRespectedTest.xml
+++ b/app/code/Magento/PageBuilder/Test/Mftf/Test/AdminCatalogCategoryPageBuilderTest/PageBuilderCatalogCategoryVerifyLayoutOverrideIsRespectedTest.xml
@@ -44,7 +44,7 @@
         <!-- Override the layout to 1 column via category design settings -->
         <actionGroup ref="SetLayoutActionGroup" stepKey="setOneColumnLayout">
             <argument name="designSection" value="CategoryDesignSection"/>
-            <argument name="layoutOption" value="1 column"/>
+            <argument name="layoutOption" value="PageBuilderFullWidthLayout.1column"/>
         </actionGroup>
 
         <!-- Save the category -->

--- a/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
+++ b/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="category.view.container">
             <referenceBlock name="category.description" template="Magento_PageBuilder::catalog/category/view/description.phtml"/>

--- a/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
+++ b/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright 2016 Adobe
+ * Copyright 2019 Adobe
  * All Rights Reserved.
  **/
 -->

--- a/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
+++ b/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */
+ * Copyright 2016 Adobe
+ * All Rights Reserved.
+ **/
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>


### PR DESCRIPTION
### Description (*)

This Pull Request removes the hardcoded `layout` attribute from `Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml`. 

Since the Magento 2.4.6-p3, this attribute forces a specific layout, making it impossible for custom themes to override the category page layout via their own XML files. Removing this attribute restores the expected layout inheritance and allows theme-level overrides to function correctly.

### Fixed Issues (if relevant)

1. magento/magento2-page-builder#829: Cannot override category layout in custom theme since 2.4.6-p3
2. magento/magento2#38473: Layout set in Magento_PageBuilder overriding layout set by theme

### Related Pull Requests

- https://github.com/magento/magento2-page-builder/pull/835#issuecomment-2563644716

### Manual testing scenarios (*)

1. Install a Magento instance (version 2.4.6-p3 or newer) with PageBuilder enabled.
2. Create or use a custom frontend theme.
3. In the custom theme, create a layout override: `app/design/frontend/[Vendor]/[Theme]/Magento_Catalog/layout/catalog_category_view.xml`.
4. Define a specific layout in that file (e.g., `<page layout="1column" ...>`).
5. Flush the cache and view a category page on the storefront.
6. **Result (Pre-fix):** The category page ignores the theme setting and sticks to the PageBuilder-defined layout.
7. **Result (Post-fix):** The category page correctly honors the layout defined in the custom theme.

### Questions or comments

N/A

### Checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)